### PR TITLE
git 'all' command to perform bulk actions on many repositories

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -26,7 +26,7 @@
   parent-update = "!git co master && git fetch parent && git reset --hard parent/master"
   amend-to = !sh -c 'git stash && git edit $1 && git stash pop && git edit --amend' -
   rprune = !git checkout master && git pull && git remote prune origin && git branch --merged | grep -v '*' | xargs git branch -d
-  all = "!f() { for i in `ls`; do if [ -d $i/.git ]; then echo \"$i\n--------------------------\"; git -C $i $1; echo; fi; done; }; f"
+  all = "!f() { for i in `ls`; do if [ -d $i/.git ]; then echo \"$i\n--------------------------\"; git -C $i $1; echo; fi; done; }; f" # perform an action on all git repositories in the current directory (for example git all pull)
 
   # shortcuts so I get autocomlete
   stached-switch = "!~/dotfiles/bin/git-stached-switch"

--- a/gitconfig
+++ b/gitconfig
@@ -26,6 +26,7 @@
   parent-update = "!git co master && git fetch parent && git reset --hard parent/master"
   amend-to = !sh -c 'git stash && git edit $1 && git stash pop && git edit --amend' -
   rprune = !git checkout master && git pull && git remote prune origin && git branch --merged | grep -v '*' | xargs git branch -d
+  all = "!f() { for i in `ls`; do if [ -d $i/.git ]; then echo \"$i\n--------------------------\"; git -C $i $1; echo; fi; done; }; f"
 
   # shortcuts so I get autocomlete
   stached-switch = "!~/dotfiles/bin/git-stached-switch"


### PR DESCRIPTION
I've a new alias which performs the specified action on all repositories in the current directory. The canonical use case is `git all pull` in my main code directory, in order to make sure that all of the repos there are up to date. 