### PR TITLE
Fix bundle-grep

### DIFF
--- a/bash/alias.sh
+++ b/bash/alias.sh
@@ -34,4 +34,4 @@ alias be="bundle exec"
 alias b="bundle check 2>&1 > /dev/null || { ((test -d vendor/cache && bundle --local --quiet) || bundle --quiet) || bundle check > /dev/null; }"
 alias bl="bundle --local --quiet"
 alias bul="bundle update --local"
-alias bundle-grep='bundle show --paths | sed "s+$PWD/++" | xargs grep --recursive --line-number'
+alias bundle-grep='bundle show --paths | sed "s+$PWD/++" | xargs grep --recursive --line-number --'


### PR DESCRIPTION
Allows to include `--` in search